### PR TITLE
Change OpeningHours regex to accept variable space

### DIFF
--- a/src/main/java/seedu/address/model/attraction/OpeningHours.java
+++ b/src/main/java/seedu/address/model/attraction/OpeningHours.java
@@ -18,7 +18,7 @@ public class OpeningHours {
     public static final String TIME_CONSTRAINTS = "Time should be in the HHMM 24-hour format";
     public static final String OPENING_HOURS_VALIDATION_REGEX =
             "(?<opensAt>([0-1][0-9]|2[0-3])[0-5][0-9])"
-            + "\\s?-\\s?"
+            + "\\s*-\\s*"
             + "(?<closesAt>([0-1][0-9]|2[0-3])[0-5][0-9])$";
     // Valid times: 2359, 0000, 1900
     // Invalid times: 2400, 2900

--- a/src/test/java/seedu/address/model/attraction/OpeningHoursTest.java
+++ b/src/test/java/seedu/address/model/attraction/OpeningHoursTest.java
@@ -8,10 +8,6 @@ import org.junit.jupiter.api.Test;
 
 // adapted from addressTest
 public class OpeningHoursTest {
-    @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new OpeningHours(null));
-    }
 
     @Test
     public void constructor_invalidOpeningHours_throwsIllegalArgumentException() {
@@ -25,12 +21,13 @@ public class OpeningHoursTest {
         assertThrows(NullPointerException.class, () -> OpeningHours.isValidOpeningHours(null));
 
         // invalid opening hours
-        assertFalse(OpeningHours.isValidOpeningHours("500 - 2100")); // Missing zero
-        assertFalse(OpeningHours.isValidOpeningHours("0700  -  0800")); // too many spaces
+        assertFalse(OpeningHours.isValidOpeningHours("500 - 2300")); // Missing zero
+        assertFalse(OpeningHours.isValidOpeningHours("00700 - 2300")); // too many digits
 
         // valid opening hours
-        assertTrue(OpeningHours.isValidOpeningHours("0100 - 0200"));
-        assertTrue(OpeningHours.isValidOpeningHours("2200 - 0300")); // spanning over midnight
+        assertTrue(OpeningHours.isValidOpeningHours("0300 - 2300"));
+        assertTrue(OpeningHours.isValidOpeningHours("0300   -       2300")); // accepts spaces
+        assertTrue(OpeningHours.isValidOpeningHours("2300 - 0300")); // spanning over midnight
         assertTrue(OpeningHours.isValidOpeningHours("0000 - 2359")); // 24 hour
     }
 


### PR DESCRIPTION
OpeningHours regex only accepts 0-1 spaces.

Changing this allows the regex to be more lenient.

Improves the user experience, by accepting non-problematic minor typos.