### PR TITLE
Change price regex to accept decimals and units

### DIFF
--- a/src/main/java/seedu/address/model/attraction/Price.java
+++ b/src/main/java/seedu/address/model/attraction/Price.java
@@ -1,11 +1,11 @@
 package seedu.address.model.attraction;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents an attraction's expected cost in Maplet.

--- a/src/test/java/seedu/address/model/attraction/PriceTest.java
+++ b/src/test/java/seedu/address/model/attraction/PriceTest.java
@@ -29,12 +29,12 @@ public class PriceTest {
         assertFalse(Price.isValidPrice("")); // empty string
 
         // valid price
-        assertTrue(Price.isValidPrice("JPY 200"));// 3 Letter currency code
+        assertTrue(Price.isValidPrice("JPY 200")); // 3-letter iso code
         assertTrue(Price.isValidPrice("$2")); // no space
         assertTrue(Price.isValidPrice("USD 12.20")); // decimals
         assertTrue(Price.isValidPrice("5 USD")); // Units at the end
         assertTrue(Price.isValidPrice("5$")); // Units at the end
-        assertTrue(Price.isValidPrice("US$ 5")); // 2-letter iso code with D replaced by $
+        assertTrue(Price.isValidPrice("US$ 5")); // 3-letter iso code with D replaced by $
         assertTrue(Price.isValidPrice("5")); // No units
         assertTrue(Price.isValidPrice("5           US$")); // A lot of spaces
         assertTrue(Price.isValidPrice("5")); // A lot of spaces


### PR DESCRIPTION
Price does not accept units or decimals, resulting in limited functionality.

Adding currencies support, as well as decimals, allow for users to enter more specific information into Maplet.

The regex is restricted to the 3 letter ISO code or the currency symbol itself allows for these functionalities, but without resulting in too much unintended behaviour.