### PR TITLE
Update Maplet's exit message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Maplet as requested ...";
 
     @Override
     public CommandResult execute(Model model) {


### PR DESCRIPTION
Maplet's exit message mentions AddressBook, which is not the app name.

Updating the message to have Maplet instead of AddressBook.

For better naming consistency.